### PR TITLE
Disponibilizado campo 'sold_quantity' na consulta de um anuncio (produto)

### DIFF
--- a/src/Entity/Product/Product.php
+++ b/src/Entity/Product/Product.php
@@ -38,6 +38,7 @@ class Product extends EntityAbstract implements EntityInterface
             'seller_id' => 'string',
             'permalink' => 'string',
             'attributes' => 'array',
+            'sold_quantity' => 'integer',
         ];
     }
 }

--- a/tests/Entity/Product/ProductGeneratedTest.php
+++ b/tests/Entity/Product/ProductGeneratedTest.php
@@ -76,6 +76,7 @@ class ProductGeneratedTest extends CoreTestCase
             'shipping' => 'array',
             'official_store_id' => 'number',
             'status' => 'string',
+            'sold_quantity' => 'integer',
         ];
 
         return $this->dataProviderEntitySchema(self::QUALIFIED, $expected);
@@ -499,5 +500,35 @@ class ProductGeneratedTest extends CoreTestCase
     {
         $product->setStatus($expected['status']);
         $this->assertSame($expected['status'], $product->getStatus());
+    }
+
+    /**
+     * @testdox Have a getter ``getSoldQuantity()`` to get ``SoldQuantity``
+     * @dataProvider dataProviderProduct
+     * @cover ::getSoldQuantity
+     * @small
+     *
+     * @param Product $product  Main Object
+     * @param array   $expected Fixture data
+     */
+    public function testGetSoldQuantity(Product $product, array $expected)
+    {
+        $product->setStatus($expected['sold_quantity']);
+        $this->assertSame($expected['sold_quantity'], $product->getStatus());
+    }
+
+    /**
+     * @testdox Have a setter ``setSoldQuantity()`` to set ``SoldQuantity``
+     * @dataProvider dataProviderProduct
+     * @cover ::setSoldQuantity
+     * @small
+     *
+     * @param Product $product  Main Object
+     * @param array   $expected Fixture data
+     */
+    public function testSetSoldQuantity(Product $product, array $expected)
+    {
+        $product->setSoldQuantity($expected['sold_quantity']);
+        $this->assertSame($expected['sold_quantity'], $product->getSoldQuantity());
     }
 }

--- a/tests/Entity/Product/ProductTest.php
+++ b/tests/Entity/Product/ProductTest.php
@@ -265,4 +265,32 @@ class ProductTest extends TestCaseAbstract
     {
         $this->assertSchemaSetter('description', 'array', $product);
     }
+
+    /**
+     * @testdox Possui método ``getSoldQuantity()`` para acessar SoldQuantity
+     * @dataProvider dataProviderProduct
+     * @cover ::get
+     * @cover ::getSchema
+     * @small
+     *
+     * @param null|mixed $expected
+     */
+    public function testGetSoldQuantity(Product $product, $expected = null)
+    {
+        $this->assertSchemaGetter('sold_quantity', 'integer', $product, $expected);
+    }
+
+    /**
+     * @testdox Possui método ``setSoldQuantity()`` que define SoldQuantity
+     * @dataProvider dataProviderProduct
+     * @cover ::set
+     * @cover ::getSchema
+     * @small
+     *
+     * @param null|mixed $expected
+     */
+    public function testSetSoldQuantity(Product $product, $expected = null)
+    {
+        $this->assertSchemaSetter('sold_quantity', 'integer', $product);
+    }
 }


### PR DESCRIPTION
A entidade 'Product' agora possui o campo inteiro 'sold_quantity' que informa o número de vendas que foram realizadas em um anúncio.