### PR TITLE
hotfix: pictures_ids cannot be null

### DIFF
--- a/src/Entity/Product/Manager.php
+++ b/src/Entity/Product/Manager.php
@@ -161,12 +161,13 @@ final class Manager extends AbstractManager
 
         if ($hasVariation) {
             unset($update['price'], $update['available_quantity'], $update['attributes']);
-            $update['variations'] = [
-                [
-                    'id' => $params['variationId'],
-                    'picture_ids' => array_map(fn($img) => $img['source'], $entity['pictures']),
-                ],
-            ];
+            $variation = [ 'id' => $params['variationId'] ];
+
+            if (isset($entity['pictures'])) {
+                $variation['picture_ids'] = array_map(fn($img) => $img['source'], $entity['pictures']);
+            }
+
+            $update['variations'] = [$variation];
         }
 
         try {


### PR DESCRIPTION
- [x] **Hotfix**: Fix ad update fails when there's no pictures to update in variation. (db8b8d34e0c7689dcba64d33a90f9ea7eab85216)