### PR TITLE
fix: Altera método de busca do item para update

### DIFF
--- a/src/Entity/Product/Manager.php
+++ b/src/Entity/Product/Manager.php
@@ -148,7 +148,7 @@ final class Manager extends AbstractManager
             $toFind = $params['itemId'];
         }
 
-        $item = $this->findById($toFind);
+        $item = $this->getItem($toFind);
 
         $update = [];
         $update['price'] = $entity['price'];


### PR DESCRIPTION
- [x] Alterado método de busca do item dentro da função [`update()`](https://github.com/gpupo/mercadolivre-sdk/blob/c45058815286b1322b839d5e30e4dec30f79be1c/src/Entity/Product/Manager.php#L143) para somente "buscar o item" (anúncio) sem a descrição, evitando os erros `404` na chamada [`getDescription()`](https://github.com/gpupo/mercadolivre-sdk/blob/c45058815286b1322b839d5e30e4dec30f79be1c/src/Entity/Product/Manager.php#L63) da função [`findById()`](https://github.com/gpupo/mercadolivre-sdk/blob/c45058815286b1322b839d5e30e4dec30f79be1c/src/Entity/Product/Manager.php#L55). (b006633c44772e224d4c03c405bf0a27d60ae4cc)
Ex.: `FAIL: Type: not_found, Message: Description of item with id MLB0000000000 not found, Status: 404`
