### PR TITLE
Adiciona chave de video_id ao schema  da entidade de Product

### DIFF
--- a/Resources/mockup/Product/MLB803848501.json
+++ b/Resources/mockup/Product/MLB803848501.json
@@ -31,7 +31,7 @@
       "quality": ""
     }
   ],
-  "video_id": null,
+  "video_id": "dQw4w9WgXcQ",
   "description": [
     {
       "id": "MLB803848501-1846315479"

--- a/src/Entity/Product/Product.php
+++ b/src/Entity/Product/Product.php
@@ -39,6 +39,7 @@ class Product extends EntityAbstract implements EntityInterface
             'permalink' => 'string',
             'attributes' => 'array',
             'sold_quantity' => 'integer',
+            'video_id' => 'string',
         ];
     }
 }

--- a/tests/Entity/Product/ProductGeneratedTest.php
+++ b/tests/Entity/Product/ProductGeneratedTest.php
@@ -43,6 +43,12 @@ use PHPUnit\Framework\TestCase as CoreTestCase;
  * @method                                                                  setShipping(array $shipping)                                                            A $shipping setter
  * @method float                                                            getOfficialStoreId()                                                                    A $official_store_id acessor.
  * @method                                                                  setOfficialStoreId(float $official_store_id)                                            A $official_store_id setter
+ * @method string                                                           getStatus()                                                                             A $status acessor.
+ * @method                                                                  setStatus(string $status)                                                               A $status setter
+ * @method int                                                              getSoldQuantity()                                                                       A $sold_quantity acessor.
+ * @method                                                                  setSoldQuantity(int $sold_quantity)                                                     A $sold_quantity setter
+ * @method string                                                           getVideoId()                                                                            A $video_id acessor.
+ * @method                                                                  setVideoId(string $video_id)                                                            A $video_id setter
  */
 class ProductGeneratedTest extends CoreTestCase
 {
@@ -77,6 +83,7 @@ class ProductGeneratedTest extends CoreTestCase
             'official_store_id' => 'number',
             'status' => 'string',
             'sold_quantity' => 'integer',
+            'video_id' => 'string',
         ];
 
         return $this->dataProviderEntitySchema(self::QUALIFIED, $expected);
@@ -513,8 +520,8 @@ class ProductGeneratedTest extends CoreTestCase
      */
     public function testGetSoldQuantity(Product $product, array $expected)
     {
-        $product->setStatus($expected['sold_quantity']);
-        $this->assertSame($expected['sold_quantity'], $product->getStatus());
+        $product->setSoldQuantity($expected['sold_quantity']);
+        $this->assertSame($expected['sold_quantity'], $product->getSoldQuantity());
     }
 
     /**
@@ -530,5 +537,35 @@ class ProductGeneratedTest extends CoreTestCase
     {
         $product->setSoldQuantity($expected['sold_quantity']);
         $this->assertSame($expected['sold_quantity'], $product->getSoldQuantity());
+    }
+
+    /**
+     * @testdox Have a getter ``getVideoId()`` to get ``VideoId``
+     * @dataProvider dataProviderProduct
+     * @cover ::getVideoId
+     * @small
+     *
+     * @param Product $product  Main Object
+     * @param array   $expected Fixture data
+     */
+    public function testGetVideoId(Product $product, array $expected)
+    {
+        $product->setVideoId($expected['video_id']);
+        $this->assertSame($expected['video_id'], $product->getVideoId());
+    }
+
+    /**
+     * @testdox Have a setter ``setVideoId()`` to set ``VideoId``
+     * @dataProvider dataProviderProduct
+     * @cover ::setVideoId
+     * @small
+     *
+     * @param Product $product  Main Object
+     * @param array   $expected Fixture data
+     */
+    public function testSetVideoId(Product $product, array $expected)
+    {
+        $product->setVideoId($expected['video_id']);
+        $this->assertSame($expected['video_id'], $product->getVideoId());
     }
 }

--- a/tests/Entity/Product/ProductTest.php
+++ b/tests/Entity/Product/ProductTest.php
@@ -293,4 +293,32 @@ class ProductTest extends TestCaseAbstract
     {
         $this->assertSchemaSetter('sold_quantity', 'integer', $product);
     }
+
+    /**
+     * @testdox Possui método ``getVideoId()`` para acessar VideoId
+     * @dataProvider dataProviderProduct
+     * @cover ::get
+     * @cover ::getSchema
+     * @small
+     *
+     * @param null|mixed $expected
+     */
+    public function testGetVideoId(Product $product, $expected = null)
+    {
+        $this->assertSchemaGetter('video_id', 'string', $product, $expected);
+    }
+
+    /**
+     * @testdox Possui método ``setVideoId()`` que define VideoId
+     * @dataProvider dataProviderProduct
+     * @cover ::set
+     * @cover ::getSchema
+     * @small
+     *
+     * @param null|mixed $expected
+     */
+    public function testSetVideoId(Product $product, $expected = null)
+    {
+        $this->assertSchemaSetter('video_id', 'string', $product);
+    }
 }


### PR DESCRIPTION
### Principais alterações:
- [x] Adicionada a chave `video_id` ao _schema_ da entidade de **Product** (132f005236a68faebcd5ae42097341e8c0fad97b)
### Outras alterações:
- [x] Definido o valor de `video_id` para o _mockup_ de **Product** (6e86d3937b7cee77c3b9b55be9869a32b74a9a65)
### Testes:
- [x] Adicionadas funções para teste do atributo de `video_id` (ae3aa59f854c0441aecbb987dce6c5e75c44f0aa)
- [x] Adicionadas _annotations_ faltantes; Corrigido corpo da função para teste do atributo `sold_quantity`; Adicionadas funções de teste para **_getter_** e **_setter_** do atributo de `video_id` (0312b6f869e80381691200fd640ea06bbb708cf9)
