### PR TITLE
Corrige atualização/definição de video_id no anúncio

### DIFF
--- a/src/Entity/Product/Manager.php
+++ b/src/Entity/Product/Manager.php
@@ -153,7 +153,7 @@ final class Manager extends AbstractManager
         $update = [];
         $update['price'] = $entity['price'];
 
-        foreach (['shipping', 'title', 'pictures', 'attributes'] as $field) {
+        foreach (['shipping', 'title', 'pictures', 'attributes', 'video_id'] as $field) {
             if (isset($entity[$field])) {
                 $update[$field] = $entity[$field];
 
@@ -178,7 +178,7 @@ final class Manager extends AbstractManager
         }
 
         if ($hasVariation) {
-            unset($update['price'], $update['available_quantity'], $update['attributes']);
+            unset($update['price'], $update['available_quantity'], $update['attributes'], $update['video_id']);
             $variation = [ 'id' => $params['variationId'] ];
 
             if (isset($entity['pictures'])) {


### PR DESCRIPTION
### Principais alterações
- [x] Adicionada chave/valor de `video_id` na função de atualização do anúncio; Remove atualização de `video_id` para anúncios de tipo "variação" (795399c7d75614dd46d82587fe0b6f3bdd8bd4c7)