### PR TITLE
Fix - corrige falta de importação do Metadata

### DIFF
--- a/src/Entity/Order/Manager.php
+++ b/src/Entity/Order/Manager.php
@@ -15,6 +15,7 @@ use Gpupo\CommonSdk\Response;
 use Gpupo\CommonSdk\Traits\LoadTrait;
 use Gpupo\CommonSdk\Traits\TranslatorManagerTrait;
 use Gpupo\MercadolivreSdk\Entity\AbstractManager;
+use Gpupo\CommonSdk\Entity\Metadata\MetadataContainer;
 
 final class Manager extends AbstractManager
 {


### PR DESCRIPTION
Estava faltando o `use Gpupo\CommonSdk\Entity\Metadata\MetadataContainer;` e isso gerou erro