### PR TITLE
hotfix - Corrige atualização de anúncio com estoque 0

### DIFF
--- a/src/Entity/Product/Manager.php
+++ b/src/Entity/Product/Manager.php
@@ -186,8 +186,8 @@ final class Manager extends AbstractManager
                 $variation['picture_ids'] = array_map(fn($img) => $img['source'], $entity['pictures']);
             }
 
-            if ($entity['available_quantity'] <= 0) {
-                $variation['available_quantity'] = 0;
+            if ((int) $entity['available_quantity'] !== (int) $item['available_quantity']) {
+                $variation['available_quantity'] = $entity['available_quantity'];
             }
 
             $update['variations'] = [$variation];

--- a/src/Entity/Product/Manager.php
+++ b/src/Entity/Product/Manager.php
@@ -186,6 +186,10 @@ final class Manager extends AbstractManager
                 $variation['picture_ids'] = array_map(fn($img) => $img['source'], $entity['pictures']);
             }
 
+            if ($entity['available_quantity'] <= 0) {
+                $variation['available_quantity'] = 0;
+            }
+
             $update['variations'] = [$variation];
         }
 
@@ -268,6 +272,8 @@ final class Manager extends AbstractManager
         $variations = $this->getAdVariations($params['itemId']);
         $variations = $variations->get('variations');
 
+        $item = $this->findItemById($params['itemId']);
+
         if (empty($variations)) {
             throw new AdWithoutVariationException('The ad has no variations');
         }
@@ -279,7 +285,7 @@ final class Manager extends AbstractManager
         $variation = [];
         $variation['price'] = $entity['price'];
    
-        if ($entity['available_quantity'] > 0) {
+        if ((int) $item['available_quantity'] !== (int) $entity['available_quantity']) {
             $variation['available_quantity'] = $entity['available_quantity'];
         }
 


### PR DESCRIPTION
Ao tentar atualizar anuncios com variacao estavamos removendo o `available_quantity`, e isso fez com que o anúncio fosse reaberto novamente um tempo depois